### PR TITLE
Move .npmrc settings to pnpm-workspace.yaml

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-node-linker=hoisted
-link-workspace-packages=true
-save-prefix=''

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
+# .npmrc settings
+nodeLinker: hoisted
+linkWorkspacePackages: true
+savePrefix: ""
+
 packages:
   - apps/*
   - packages/*


### PR DESCRIPTION
Moved `.npmrc` settings to `pnpm-workspace.yaml` to consolidate package management configuration into a single file. The configuration maintains the same settings for node linking (hoisted), workspace package linking (true), and save prefix (empty string).